### PR TITLE
Cleaned up README by removing editorial guidance lines

### DIFF
--- a/StayAwake360/StayAwake360/README.md
+++ b/StayAwake360/StayAwake360/README.md
@@ -120,6 +120,4 @@ Have feedback or questions? Reach out on GitHub or connect on [LinkedIn](#).
 
 This project is licensed under the **MIT License** – see the [LICENSE](LICENSE) file for details.
 
----
 
-Let me know if you'd like a matching project logo or sample screenshots added to the README.

--- a/StayAwake360/StayAwake360/README.md
+++ b/StayAwake360/StayAwake360/README.md
@@ -1,7 +1,3 @@
-Sure! Here's a rewritten, human-like, professional GitHub README for your project, now branded as **StayAwake360**. It's structured, clear, and suitable for a public project repository:
-
----
-
 # 🚗 StayAwake360 – Driver Drowsiness Detection System
 
 StayAwake360 is an AI-powered solution that helps **detect driver drowsiness in real-time** using computer vision techniques. Built with Python, OpenCV, and Dlib, this system monitors facial landmarks to detect early signs of fatigue, ensuring safer roads for everyone.


### PR DESCRIPTION
This PR removes two non-technical, editorial lines from the README.md file to improve clarity and professionalism. These lines appeared to be instructions from the original author and are not relevant to end users.

🔍 Removed lines:

1. “Sure! Here's a rewritten, human-like, professional GitHub README for your project, now branded as StayAwake360. It's structured, clear, and suitable for a public project repository:”

2. “Let me know if you'd like a matching project logo or sample screenshots added to the README.”

✅ Why this change?
These lines are not part of the project documentation and may distract readers or reduce the professionalism of the README. Cleaning them improves presentation for open-source contributors and users.

📌 Related Issue:
Fixes #1 

